### PR TITLE
Temp sorl thumbnail

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ django-crispy-forms==1.7.2
 django-downloadview==1.9
 django-js-reverse==0.9.1
 Pillow==6.2.1
-git+git://https://github.com/jazzband/sorl-thumbnail@4fe1854#egg=sorl-thumbnail
+git+git://github.com/jazzband/sorl-thumbnail@4fe1854#egg=sorl-thumbnail

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ django-crispy-forms==1.7.2
 django-downloadview==1.9
 django-js-reverse==0.9.1
 Pillow==6.2.1
-sorl-thumbnail==12.4.1
+git+git://https://github.com/jazzband/sorl-thumbnail@4fe1854#egg=sorl-thumbnail

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django==3.0
 django-annoying==0.10.3
-django-debug-toolbar==1.11
+django-debug-toolbar==2.1
 django-crispy-forms==1.7.2
 django-downloadview==1.9
 django-js-reverse==0.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django==3.0
 django-annoying==0.10.3
 django-debug-toolbar==2.1
-django-crispy-forms==1.7.2
+django-crispy-forms==1.8.1
 django-downloadview==1.9
 django-js-reverse==0.9.1
 Pillow==6.2.1


### PR DESCRIPTION
- Use a temp version of sorl-thumbnail until a release is made.

- Upgrade crispy forms to the latest

- Upgrade debug toolbar to the latest
